### PR TITLE
modified passing of parameters in the POST portion of the Client.request method

### DIFF
--- a/flickr.py
+++ b/flickr.py
@@ -284,8 +284,8 @@ class FlickrAPI(object):
                     }
 
             else:
-                url = self.rest_api_url + '?' + urllib.urlencode(qs)
-                resp, content = self.client.request(url, 'POST', urllib.urlencode(params), headers=self.headers)
+                url = self.rest_api_url + '?' + urllib.urlencode(qs) + '&' + urllib.urlencode(params)
+                resp, content = self.client.request(url, 'POST', headers=self.headers)
         else:
             params.update(qs)
             resp, content = self.client.request('%s?%s' % (self.rest_api_url, urllib.urlencode(params)), 'GET', headers=self.headers)


### PR DESCRIPTION
since oauth2 discards parameters when the content type is JSON. I had to make this change in order to do POST for the flickr API method flickr.photosets.create (which is a POST with no data and a couple of required parameters). The flickr API was complaining that  my request did not include those parameters and I found out that since the content type is JSON, when these parameters get passed to oauth2 client, they get dropped since oauth2 is only looking for parameters of application/x-www-form-urlencoded.
